### PR TITLE
Clicking on "Need help" now leads to Fliplet documentation about Video.

### DIFF
--- a/css/interface.css
+++ b/css/interface.css
@@ -37,8 +37,3 @@
 .info-holder .btn-link.text-danger:hover {
     color: #a94442 !important;
 }
-@media only screen and (min-width: 488px) {
-    header {
-        font-size: 1.0em;
-    }
-}

--- a/interface.html
+++ b/interface.html
@@ -1,7 +1,7 @@
 <div class="widget-holder form-horizontal">
   <header>
       <p>Configure your offline video</p>
-      <a href="#">Need help?</a>
+      <a href="https://help.fliplet.com/article/164-video-components">Need help?</a>
   </header>
 
   <div class="section">


### PR DESCRIPTION
@tonytlwu @squallstar

Issue
Fliplet/fliplet-studio#4959

Description
Added link on "Need help" button. Removed not needed media query.

Backward compatibility
This change is fully backward compatible.